### PR TITLE
install device-factory-fdt script and its deps

### DIFF
--- a/create_initramfs.sh
+++ b/create_initramfs.sh
@@ -163,6 +163,10 @@ FROM_ROOTFS=(
     /sbin/sfdisk
     /usr/lib/wb-utils/prepare/vars.sh
     /usr/lib/wb-utils/prepare/partitions.sh
+    /usr/lib/wb-utils/device-factory-fdt.sh
+    /usr/bin/dtc
+    /usr/bin/fdtoverlay
+    /usr/bin/fdtget
     /usr/bin/rsync
     /usr/bin/mmc
     /bin/dd

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initenv (1.2.1) stable; urgency=medium
+
+  * add utils for FIT compatibility check via factory FDT
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 21 Aug 2023 15:00:28 +0600
+
 wb-initenv (1.2.0) stable; urgency=medium
 
   * switch to Debian bullseye


### PR DESCRIPTION
Зависит от https://github.com/wirenboard/wb-utils/pull/126, нужно для того, чтобы на 7.4 нормально работали проверки в бутлете