### PR TITLE
Update README.ramdisk.txt

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-initenv (1.2.2) stable; urgency=medium
+
+  * update README in ramdisk, no functional changes
+    Co-authored-by: Alexander Degtyarev
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 28 Nov 2023 15:45:56 +0600
+
 wb-initenv (1.2.1) stable; urgency=medium
 
   * add utils for FIT compatibility check via factory FDT

--- a/files/README.ramdisk.txt
+++ b/files/README.ramdisk.txt
@@ -1,4 +1,4 @@
 1) Place wb_update.fit file here
-2) Safely remove/umount the drive in the OS
-3) Update will start immediately
-4) Use wb_update_FACTORYRESET.fit to REMOVE ALL YOUR FILES AND DATA
+2) As soon as the file is loaded, the controller will automatically umount the drive and the flashing of the device will begin.
+
+Use wb_update_FACTORYRESET.fit to REMOVE ALL YOUR FILES AND DATA


### PR DESCRIPTION
In WB7.4, when flashing via Debug Network, you no longer need to unmount the drive.

Changed instructions in README.ramdisk.txt