### PR TITLE
init: reduce watchdog timeout to 500ms; wb8: build initramfs from sta…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-initenv (1.3.1) stable; urgency=medium
+
+  * build wb8 initramfs from stable fit
+  * init: reduce all watchdogs timeouts to 500ms
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Wed, 15 May 2024 13:15:45 +0300
+
 wb-initenv (1.3.0) stable; urgency=medium
 
   * add Wiren Board 8 support

--- a/files/init
+++ b/files/init
@@ -35,7 +35,7 @@ mkdir -p /var/lock
 
 for file in /dev/watchdog*; do
 	echo "Run busybox watchdog for $file"
-	/bin/busybox watchdog "$file" -t 1 -F &
+	/bin/busybox watchdog "$file" -t 500ms
 done
 
 source /lib/libupdate.sh

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -10,17 +10,7 @@ if [ -z "$PLATFORM" ]; then
     exit 1
 fi
 
-# FIXME: use stable for WB8 when it's released
-case "$PLATFORM" in
-    8x)
-        RELEASE="testing"
-        ;;
-    *)
-        RELEASE="stable"
-        ;;
-esac
-
-IMAGE_URL=${2:-"http://fw-releases.wirenboard.com/fit_image/${RELEASE}/${PLATFORM}/latest.fit"}
+IMAGE_URL=${2:-"http://fw-releases.wirenboard.com/fit_image/stable/${PLATFORM}/latest.fit"}
 
 if ! which fpm || ! which dumpimage || ! which cpio; then
     # won't be used on CI after https://github.com/wirenboard/wirenboard/pull/163 is merged


### PR DESCRIPTION
…ble build

игрался с инициаллизацией wb8 на производстве - увидел, что периодически wb вырубаются по вочдогу во время wb-run-update

порисёчил:
- с wbec всё ок
- не похоже, что это из-за общей длительности инициаллизации (слипов натыкал для теста)

неожиданно вылечилось более частым пинанием вочдогов