### PR TITLE
mount debugfs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initenv (1.3.2) stable; urgency=medium
+
+  * mount debugfs
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Mon, 05 Aug 2024 13:02:39 +0300
+
 wb-initenv (1.3.1) stable; urgency=medium
 
   * build wb8 initramfs from stable fit

--- a/files/init
+++ b/files/init
@@ -21,6 +21,8 @@ start_debug_console() {
 
 trap 'start_debug_console' EXIT
 
+mount -t debugfs none /sys/kernel/debug
+
 /bin/mknod /dev/null c 1 3
 /bin/mknod /dev/tty c 5 0
 


### PR DESCRIPTION
вбеку вытащили в debugfs флажок, что он успешно завёлся
а debugfs-то у нас и не было