### PR TITLE
wb8: add modprobe dwmac_sun8i to init (enables ethernet in bootlet)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initenv (1.3.4) stable; urgency=medium
+
+  * wb8: add modprobe dwmac_sun8i to init (enables ethernet in bootlet)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 17 Oct 2024 13:03:21 +0300
+
 wb-initenv (1.3.3) stable; urgency=medium
 
   * add chattr & lsattr tools

--- a/files/init
+++ b/files/init
@@ -428,6 +428,7 @@ case "$BOOTMODE" in
 		# Wiren Board 8 does not support USB gadget yet
 		if [ "$BOARD_FAMILY" == "wb8" ]; then
 			echo "Activating Ethernet"
+			modprobe dwmac_sun8i || true
 			touch /var/leases
 			ifconfig eth0 192.168.41.1 netmask 255.255.255.0 up
 			udhcpd


### PR DESCRIPTION
Игрался с инициаллизацией и увидел, что в бутлете WB8 нет езернета. Предполагаю, началось после перекапывания @webconn конфигов ядра.

Помогло - modprobe dwmac_sun8i (почему - тайна, покрытая мраком). CONFIG_DWMAC_SUN8I=y в бутлетовский конфиг - не помогло

предлагаю - внедрить этот костыль и сильно не закапываться
собрал бутлет, проверил - интернет интернетит