### PR TITLE
Feature/wb85 usb update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initenv (1.3.4) stable; urgency=medium
+
+  * wb8: enable usbgadget
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Fri, 18 Oct 2024 12:27:38 +0300
+
 wb-initenv (1.3.3) stable; urgency=medium
 
   * add chattr & lsattr tools

--- a/files/init
+++ b/files/init
@@ -341,7 +341,8 @@ wait_usb_gadget_connected() {
 }
 
 is_usb_gadget_supported() {
-	[[ "${BOARD_FAMILY}" == "wb7" ]]
+	# [[ "${BOARD_FAMILY}" == "wb7" ]]
+	[[ "${BOARD_FAMILY}" == "wb8" ]]
 }
 
 setup_usb_ram_mass_storage() {

--- a/files/init
+++ b/files/init
@@ -341,8 +341,7 @@ wait_usb_gadget_connected() {
 }
 
 is_usb_gadget_supported() {
-	# [[ "${BOARD_FAMILY}" == "wb7" ]]
-	[[ "${BOARD_FAMILY}" == "wb8" ]]
+	[[ "${BOARD_FAMILY}" == "wb8" || "${BOARD_FAMILY}" == "wb7" ]]
 }
 
 setup_usb_ram_mass_storage() {
@@ -425,32 +424,20 @@ case "$BOOTMODE" in
 		FLAG=/flag
 
 		wait_for_emmc
+		# create usb_mass_storage first
+		dd if=/dev/zero of=$FLAG bs=1K count=1
+		echo "Activate Mass Storage device"
+		led red trigger mmc0
+		modprobe g_mass_storage file=$EMMC,$FLAG iManufacturer="Wiren Board" iProduct="Wiren Board"
+		while [ "x" == "x$_FLAG" ]; do sleep 2; _FLAG=`cat $FLAG`; done
 
-		# Wiren Board 8 does not support USB gadget yet
-		if [ "$BOARD_FAMILY" == "wb8" ]; then
-			echo "Activating Ethernet"
-			touch /var/leases
-			ifconfig eth0 192.168.41.1 netmask 255.255.255.0 up
-			udhcpd
-			while ! ping -c 1 192.168.41.2; do true; done; echo 'Host is online'
-			echo "Now you can access device by ssh: ssh root@192.168.41.1"
-			dropbear -F -E
-		else
-			# create usb_mass_storage first
-			dd if=/dev/zero of=$FLAG bs=1K count=1
-			echo "Activate Mass Storage device"
-			led red trigger mmc0
-			modprobe g_mass_storage file=$EMMC,$FLAG iManufacturer="Wiren Board" iProduct="Wiren Board"
-			while [ "x" == "x$_FLAG" ]; do sleep 2; _FLAG=`cat $FLAG`; done
+		echo "Deactivate Mass Storage device and reread partition table"
+		modprobe -r g_mass_storage
+		sleep 1
+		blockdev --rereadpt $EMMC
+		sleep 1
 
-			echo "Deactivate Mass Storage device and reread partition table"
-			modprobe -r g_mass_storage
-			sleep 1
-			blockdev --rereadpt $EMMC
-			sleep 1
-
-			setup_usb_ssh &
-		fi
+		setup_usb_ssh &
 		;;
 esac
 


### PR DESCRIPTION
По каким-то причинам, обновление через debug-network было отключено в wb8; проверил-включил

как погонять:
положить [fit](https://jenkins.wirenboard.com/job/pipelines/job/build-image/8163/) в /mnt/data/.wb-restore/factoryreset.fit
попробовать вот [это](https://wirenboard.com/wiki/Wiren_Board_8_Firmware_Update#%D0%9F%D1%80%D0%BE%D1%88%D0%B8%D0%B2%D0%BA%D0%B0_%D1%87%D0%B5%D1%80%D0%B5%D0%B7_Debug_Network) любым фитом

upd: альтернативный (и более простой) способ погонять - [здес](https://github.com/wirenboard/wb-utils/pull/163)