### PR TITLE
Bugfix/wb851 flash order

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initenv (1.3.7) stable; urgency=medium
+
+  * wb8: change update-order (usb -> debug_network); speedup usb detection
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 28 Nov 2024 21:10:11 +0300
+
 wb-initenv (1.3.6) stable; urgency=medium
 
   * wb8.5x: fix buzzer to be compatible with posix sh

--- a/files/init
+++ b/files/init
@@ -411,6 +411,8 @@ update_auto_routine_combined_debug_usb() {
 	button_init
 	enable_emmc_update="y"
 
+	echo "Hold FW button to enable flashing via debug-network"
+
 	if is_any_usb_a_inserted && search_for_usb_drive; then
 		enable_emmc_update="n"
 		update_from_block_device "/dev/sd*" "" "USB Flash Drive"

--- a/files/init
+++ b/files/init
@@ -117,6 +117,17 @@ check_fit_end_signature() {
 	[[ "$sig" == "$UPDATE_FIT_END_SIGNATURE" ]]
 }
 
+is_any_usb_a_inserted() {
+	local compat_str="wirenboard,usb-flashing-drive"
+	local hub_number=`grep -l $compat_str /sys/bus/usb/devices/*/of_node/compatible | tr -d -c 0-9 | cut -b 1`
+
+	if [[ ! -z $hub_number ]]; then
+		[[ `ls -d /sys/bus/usb/devices/${hub_number}* | wc -l` -gt 1 ]]
+	else  # fallback way: consider as inserted
+		/bin/true
+	fi
+}
+
 search_for_usb_drive() {
 	echo "Load modules for USB to work"
 	modprobe -q usb-storage

--- a/files/init
+++ b/files/init
@@ -433,11 +433,18 @@ update_auto_routine_combined_debug_usb() {
 	fi
 }
 
+is_board_wb85() {
+	# because of both 8x-85-compatible bootlet dts, we cannot guess board type via of_node/compatible way
+	# getting board type by wbec firmware's internal guess
+	local board_rev_by_wbec=`cat /sys/bus/spi/drivers/wbec/spi0.0/hwrev 2>/dev/null || true`
+	[[ $board_rev_by_wbec == "85" ]]
+}
+
 case "$BOOTMODE" in
 	update_auto)
 		is_usb_gadget_supported && setup_usb_ram_mass_storage
 
-		if [ "$BOARD_FAMILY" == "wb8" ]; then
+		if [ "$BOARD_FAMILY" == "wb8" ] && is_board_wb85; then
 			update_auto_routine_combined_debug_usb
 		else
 			update_auto_routine_not_combined_debug_usb

--- a/files/init
+++ b/files/init
@@ -437,7 +437,7 @@ is_board_wb85() {
 	# because of both 8x-85-compatible bootlet dts, we cannot guess board type via of_node/compatible way
 	# getting board type by wbec firmware's internal guess
 	local board_rev_by_wbec=`cat /sys/bus/spi/drivers/wbec/spi0.0/hwrev 2>/dev/null || true`
-	[[ $board_rev_by_wbec == "85" ]]
+	[[ "$board_rev_by_wbec" == "85" ]]
 }
 
 case "$BOOTMODE" in

--- a/files/init
+++ b/files/init
@@ -388,14 +388,24 @@ case "$BOOTMODE" in
 
 		is_usb_gadget_supported && setup_usb_ram_mass_storage
 
-		if is_usb_gadget_supported && check_usb_gadget_cable_present && wait_usb_gadget_connected; then
-			enable_emmc_update="n"
-			wait_for_update_from_gadget
-		fi
-
-		if force_enable_usb_host && search_for_usb_drive; then
-			enable_emmc_update="n"
-			update_from_block_device "/dev/sd*" "" "USB Flash Drive"
+		if [ "$BOARD_FAMILY" == "wb8" ]; then  # WB8+: USB first
+			if force_enable_usb_host && is_any_usb_a_inserted && search_for_usb_drive; then
+				enable_emmc_update="n"
+				update_from_block_device "/dev/sd*" "" "USB Flash Drive"
+			fi
+			if is_usb_gadget_supported && check_usb_gadget_cable_present && wait_usb_gadget_connected; then
+				enable_emmc_update="n"
+				wait_for_update_from_gadget
+			fi
+		else  # Before WB8: Debug-network first
+			if is_usb_gadget_supported && check_usb_gadget_cable_present && wait_usb_gadget_connected; then
+				enable_emmc_update="n"
+				wait_for_update_from_gadget
+			fi
+			if force_enable_usb_host && search_for_usb_drive; then
+				enable_emmc_update="n"
+				update_from_block_device "/dev/sd*" "" "USB Flash Drive"
+			fi
 		fi
 
 		if search_for_sd; then

--- a/files/init
+++ b/files/init
@@ -123,7 +123,7 @@ is_any_usb_a_inserted() {
 
 	if [[ ! -z $hub_number ]]; then
 		[[ `ls -d /sys/bus/usb/devices/${hub_number}* | wc -l` -gt 1 ]]
-	else  # fallback way: consider as inserted
+	else  # fallback way: consider as something is inserted
 		/bin/true
 	fi
 }
@@ -382,41 +382,63 @@ setup_usb_ssh() {
 	dropbear -F -E
 }
 
+update_auto_routine_not_combined_debug_usb() {
+	# before WB8.5; update order: debug network -> usb a -> microsd -> factory fit
+	enable_emmc_update="y"
+
+	if is_usb_gadget_supported && check_usb_gadget_cable_present && wait_usb_gadget_connected; then
+		enable_emmc_update="n"
+		wait_for_update_from_gadget
+	fi
+
+	if force_enable_usb_host && search_for_usb_drive; then
+		enable_emmc_update="n"
+		update_from_block_device "/dev/sd*" "" "USB Flash Drive"
+	fi
+
+	if search_for_sd; then
+		enable_emmc_update="n"
+		update_from_block_device "${MICROSD}p*" "" "microSD card"
+	fi
+
+	if [[ "x${enable_emmc_update}" == "xy" ]]; then
+		update_from_emmc ".wb-restore/factoryreset.fit" --no-remove --from-emmc-factoryreset
+	fi
+}
+
+update_auto_routine_combined_debug_usb() {
+	# since WB8.5; update order: usb a (faster search) -> microsd -> debug network (w pressed fw button) -> factory fit
+	enable_emmc_update="y"
+
+	if is_any_usb_a_inserted && search_for_usb_drive; then
+		enable_emmc_update="n"
+		update_from_block_device "/dev/sd*" "" "USB Flash Drive"
+	fi
+
+	if search_for_sd; then
+		enable_emmc_update="n"
+		update_from_block_device "${MICROSD}p*" "" "microSD card"
+	fi
+
+	if button_down && is_usb_gadget_supported && check_usb_gadget_cable_present && wait_usb_gadget_connected; then
+		enable_emmc_update="n"
+		wait_for_update_from_gadget
+	fi
+
+	if [[ "x${enable_emmc_update}" == "xy" ]]; then
+		update_from_emmc ".wb-restore/factoryreset.fit" --no-remove --from-emmc-factoryreset
+	fi
+}
+
 case "$BOOTMODE" in
 	update_auto)
-		enable_emmc_update="y"
-
 		is_usb_gadget_supported && setup_usb_ram_mass_storage
 
-		if [ "$BOARD_FAMILY" == "wb8" ]; then  # WB8+: USB first
-			if force_enable_usb_host && is_any_usb_a_inserted && search_for_usb_drive; then
-				enable_emmc_update="n"
-				update_from_block_device "/dev/sd*" "" "USB Flash Drive"
-			fi
-			if is_usb_gadget_supported && check_usb_gadget_cable_present && wait_usb_gadget_connected; then
-				enable_emmc_update="n"
-				wait_for_update_from_gadget
-			fi
-		else  # Before WB8: Debug-network first
-			if is_usb_gadget_supported && check_usb_gadget_cable_present && wait_usb_gadget_connected; then
-				enable_emmc_update="n"
-				wait_for_update_from_gadget
-			fi
-			if force_enable_usb_host && search_for_usb_drive; then
-				enable_emmc_update="n"
-				update_from_block_device "/dev/sd*" "" "USB Flash Drive"
-			fi
+		if [ "$BOARD_FAMILY" == "wb8" ]; then
+			update_auto_routine_combined_debug_usb
+		else
+			update_auto_routine_not_combined_debug_usb
 		fi
-
-		if search_for_sd; then
-			enable_emmc_update="n"
-			update_from_block_device "${MICROSD}p*" "" "microSD card"
-		fi
-
-		if [[ "x${enable_emmc_update}" == "xy" ]]; then
-			update_from_emmc ".wb-restore/factoryreset.fit" --no-remove --from-emmc-factoryreset
-		fi
-
 		;;
 	usbupdate*)
 		FIT_NAME="${BOOTMODE#*,}"

--- a/files/init
+++ b/files/init
@@ -408,6 +408,7 @@ update_auto_routine_not_combined_debug_usb() {
 
 update_auto_routine_combined_debug_usb() {
 	# since WB8.5; update order: usb a (faster search) -> microsd -> debug network (w pressed fw button) -> factory fit
+	button_init
 	enable_emmc_update="y"
 
 	if is_any_usb_a_inserted && search_for_usb_drive; then


### PR DESCRIPTION
проблема: в WB851 теперь один USB-c с совмещенными debug-network и миникомом => если прошивать WB, отслеживая процесс по миникому, WB будет пытаться прошиться только через debug-network

=> предлагаю решение (вроде возражений у инженеров не возникало):
подвигать очередь (было: debug-network -> usb -> microsd -> factory-fit; стало: быстрый usb -> microsd -> debug-network-c-нажатой кнопкой -> factory-fit)

погонял - на 851 процедура новая; 84 - старая; 74 - старая => что и ожидаем
@lostpoint-ru тоже потыкал на 851; инженеры что-то тыкали

factory-fit-ы подменять не надо, пот 851 еще не продаём, а склад - перешьём