### PR TITLE
Rename debug-network to Debug USB

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initenv (1.3.9) stable; urgency=medium
+
+  * Rename debug-network to Debug USB
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 08 Apr 2025 16:30:44 +0300
+
 wb-initenv (1.3.8) stable; urgency=medium
 
   * add e2fsck & fdisk tools

--- a/files/init
+++ b/files/init
@@ -411,7 +411,7 @@ update_auto_routine_combined_debug_usb() {
 	button_init
 	enable_emmc_update="y"
 
-	echo "Hold FW button to enable flashing via debug-network"
+	echo "Hold FW button to enable flashing via Debug USB"
 
 	if is_any_usb_a_inserted && search_for_usb_drive; then
 		enable_emmc_update="n"


### PR DESCRIPTION
Переименовали порт в пользовательском выводе. Поискала по организации, есть еще написание debug-network в комментариях и системных файлах для этого самого debug-network, но наверное не будем это исправлять.