### PR TITLE
Remove wb-utils/prepare from rootfs

### DIFF
--- a/create_initramfs.sh
+++ b/create_initramfs.sh
@@ -189,8 +189,6 @@ FROM_ROOTFS=(
     /usr/lib/sftp-server
 
     /sbin/sfdisk
-    /usr/lib/wb-utils/prepare/vars.sh
-    /usr/lib/wb-utils/prepare/partitions.sh
     /usr/lib/wb-utils/device-factory-fdt.sh
     /usr/bin/dtc
     /usr/bin/fdtoverlay

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initenv (1.4.0) stable; urgency=medium
+
+  * Remove wb-utils/prepare from rootfs
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 18 Jul 2025 11:10:00 +0400
+
 wb-initenv (1.3.9) stable; urgency=medium
 
   * Rename debug-network to Debug USB

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,102 +1,102 @@
-wb-initenv (1.4.0) stable; urgency=medium
+wb-initramfs (1.4.0) stable; urgency=medium
 
   * Remove wb-utils/prepare from rootfs
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 18 Jul 2025 11:10:00 +0400
 
-wb-initenv (1.3.9) stable; urgency=medium
+wb-initramfs (1.3.9) stable; urgency=medium
 
   * Rename debug-network to Debug USB
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 08 Apr 2025 16:30:44 +0300
 
-wb-initenv (1.3.8) stable; urgency=medium
+wb-initramfs (1.3.8) stable; urgency=medium
 
   * add e2fsck & fdisk tools
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 04 Feb 2025 21:13:29 +0300
 
-wb-initenv (1.3.7) stable; urgency=medium
+wb-initramfs (1.3.7) stable; urgency=medium
 
   * wb8: change update-order (usb -> debug_network); speedup usb detection
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 28 Nov 2024 21:10:11 +0300
 
-wb-initenv (1.3.6) stable; urgency=medium
+wb-initramfs (1.3.6) stable; urgency=medium
 
   * wb8.5x: fix buzzer to be compatible with posix sh
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 12 Nov 2024 23:01:22 +0300
 
-wb-initenv (1.3.5) stable; urgency=medium
+wb-initramfs (1.3.5) stable; urgency=medium
 
   * wb8.5x: enable buzzer in initramfs (wb8.4x compatible too)
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Fri, 08 Nov 2024 17:38:21 +0300
 
-wb-initenv (1.3.4) stable; urgency=medium
+wb-initramfs (1.3.4) stable; urgency=medium
 
   * wb8: enable usbgadget
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Fri, 18 Oct 2024 12:27:38 +0300
 
-wb-initenv (1.3.3) stable; urgency=medium
+wb-initramfs (1.3.3) stable; urgency=medium
 
   * add chattr & lsattr tools
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Mon, 23 Sep 2024 14:36:29 +0300
 
-wb-initenv (1.3.2) stable; urgency=medium
+wb-initramfs (1.3.2) stable; urgency=medium
 
   * mount debugfs
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Mon, 05 Aug 2024 13:02:39 +0300
 
-wb-initenv (1.3.1) stable; urgency=medium
+wb-initramfs (1.3.1) stable; urgency=medium
 
   * build wb8 initramfs from stable fit
   * init: reduce all watchdogs timeouts to 500ms
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Wed, 15 May 2024 13:15:45 +0300
 
-wb-initenv (1.3.0) stable; urgency=medium
+wb-initramfs (1.3.0) stable; urgency=medium
 
   * add Wiren Board 8 support
 
  -- Nikita Maslov <nikita.maslov@wirenboard.com>  Fri, 26 Apr 2024 13:46:31 +0500
 
-wb-initenv (1.2.3) stable; urgency=medium
+wb-initramfs (1.2.3) stable; urgency=medium
 
   * add WBEC flashing requirements
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 28 Mar 2024 19:31:29 +0300
 
-wb-initenv (1.2.2) stable; urgency=medium
+wb-initramfs (1.2.2) stable; urgency=medium
 
   * update README in ramdisk, no functional changes
     Co-authored-by: Alexander Degtyarev
 
  -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 28 Nov 2023 15:45:56 +0600
 
-wb-initenv (1.2.1) stable; urgency=medium
+wb-initramfs (1.2.1) stable; urgency=medium
 
   * add utils for FIT compatibility check via factory FDT
 
  -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 21 Aug 2023 15:00:28 +0600
 
-wb-initenv (1.2.0) stable; urgency=medium
+wb-initramfs (1.2.0) stable; urgency=medium
 
   * switch to Debian bullseye
 
  -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Fri, 18 Aug 2023 18:12:39 +0600
 
-wb-initenv (1.1.0) stable; urgency=medium
+wb-initramfs (1.1.0) stable; urgency=medium
 
   * make USB debug network update work without USB disconnection
 
  -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Fri, 18 Aug 2023 17:56:55 +0600
 
-wb-initenv (1.0.0) stable; urgency=medium
+wb-initramfs (1.0.0) stable; urgency=medium
 
   * Initial release, stretch
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
 # WARNING: this is a minimal control file to make dch happy.
 # Actual control file for the package will be generated using fpm in make_deb.sh
-Source: wb-initenv
+Source: wb-initramfs
 Maintainer: Wiren Board team <info@wirenboard.com>


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
В initramfs запускаем wb-run-update, который тянет за собой только device-factory-fdt.sh, prepare/partitions.sh и prepare/vars.sh не задействованы.
Изначально добавлены тут https://github.com/wirenboard/wb-initramfs/commit/c0519c0fc8229ace98fc94c4bb2c8065e931d45e
___________________________________
**Что поменялось для пользователей:**
Ничего

___________________________________
**Как проверял/а:**
пока никак, todo: собрать бутлет с этим initramfs и проверить обновление фитами

