### PR TITLE
Fix libupdate.sh

### DIFF
--- a/create_initramfs.sh
+++ b/create_initramfs.sh
@@ -75,7 +75,7 @@ install_from_rootfs() {
 	install_file "$ROOTFS/$src" "$dst"
 
 	# If file is executable, need to get its shared lib dependencies too
-	# TODO: lddtree in deb11 doesn't support --copy-to-tree, use after switch to deb13
+	# TODO: lddtree (from pax-utils) in deb11 doesn't support --copy-to-tree, use after switch to deb13
 	# lddtree --skip-non-elfs -R "$ROOTFS" --copy-to-tree "$INITRAMFS" "$src"
 	if [[ -x "$ROOTFS/$src" ]]; then
 		chroot "$ROOTFS" ldd "$src" |

--- a/create_initramfs.sh
+++ b/create_initramfs.sh
@@ -75,6 +75,8 @@ install_from_rootfs() {
 	install_file "$ROOTFS/$src" "$dst"
 
 	# If file is executable, need to get its shared lib dependencies too
+	# TODO: lddtree in deb11 doesn't support --copy-to-tree, use after switch to deb13
+	# lddtree --skip-non-elfs -R "$ROOTFS" --copy-to-tree "$INITRAMFS" "$src"
 	if [[ -x "$ROOTFS/$src" ]]; then
 		chroot "$ROOTFS" ldd "$src" |
 		sed -rn 's#[^/]*(/[^ ]*).*#\1#p' |

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initenv (1.3.10) stable; urgency=medium
+
+  * Fix libupdate.sh
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 18 Jul 2025 17:10:00 +0400
+
 wb-initenv (1.3.9) stable; urgency=medium
 
   * Rename debug-network to Debug USB

--- a/files/libupdate.sh
+++ b/files/libupdate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LIBS_PATH=/lib/
+LIBS_PATH=/lib
 DT_COMPAT_LIST=`tr < /proc/device-tree/compatible '\000' '\n'`
 
 for compat in $DT_COMPAT_LIST; do
@@ -40,7 +40,7 @@ for compat in $DT_COMPAT_LIST; do
     esac
 done
 
-source ${LIBS_PATH}/libupdate.${LIB}.sh || {
+[ -f "${LIBS_PATH}/libupdate.${LIB}.sh" ] && source ${LIBS_PATH}/libupdate.${LIB}.sh || {
     echo "Unknown platform"
     exit 1
 }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При загрузке бутлета:
```sh
Run busybox watchdog for /dev/watchdog
Run busybox watchdog for /dev/watchdog0
Run busybox watchdog for /dev/watchdog1
/init: source: line 43: can't open '/lib//libupdate..sh': No such file or directory


BusyBox v1.30.1 (Debian 1:1.30.1-6+deb11u1) built-in shell (ash)
Enter 'help' for a list of built-in commands.
```
Дело в том что ash отличается от bash:
```sh
ash# source "./foo.sh" || { echo "FOO"; }
ash: source: can't open './foo.sh': No such file or directory
bash# source "./foo.sh" || { echo "FOO"; }
bash: ./foo.sh: No such file or directory
FOO
```
C проверкой:
```sh
ash# [ -f "./foo.sh" ] && source "./foo.sh" || { echo "FOO"; }
FOO
bash# [ -f "./foo.sh" ] && source "./foo.sh" || { echo "FOO"; }
FOO
```
А почему вообще возникает `/lib//libupdate..sh`, потому что wb7 считается только `wirenboard,wirenboard-700`, а по факту:
```sh
tr < /proc/device-tree/compatible '\000' '\n'
wirenboard,wirenboard-733
wirenboard,wirenboard-73x
wirenboard,wirenboard-72x
wirenboard,wirenboard-720
wirenboard,wirenboard-7xx
allwinner,sun8i-r40
```
Немного странно, почему в 73x дтс нет wirenboard-700?
```sh
grep wirenboard-700 linux/arch/arm/boot/dts/sun8i-r40-wirenboard733.dts
```
А в остальных уже есть:
```sh
grep wirenboard-700 linux/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
	compatible = "wirenboard,wirenboard-720", "wirenboard,wirenboard-72x", "wirenboard,wirenboard-700", "wirenboard,wirenboard-7xx", "allwinner,sun8i-r40";
grep wirenboard-700 linux/arch/arm/boot/dts/sun8i-r40-wirenboard741.dts
	compatible = "wirenboard,wirenboard-741", "wirenboard,wirenboard-740", "wirenboard,wirenboard-74x", "wirenboard,wirenboard-73x", "wirenboard,wirenboard-72x", "wirenboard,wirenboard-720", "wirenboard,wirenboard-700", "wirenboard,wirenboard-7xx", "allwinner,sun8i-r40";
```
Ну и по всей этой логике баззер (инициализация живет в /lib/libupdate.wb7.sh) не должен работать на wb73 при обновлении, но он работает (как?).
___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
загрузившись в бутлет

