### PR TITLE
Fix factoryreset.fit path on extended rootfs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,16 @@
+wb-initramfs (1.5.1) stable; urgency=medium
+
+  * Fix factoryreset.fit path on extended rootfs
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 25 Jul 2025 15:00:00 +0400
+
 wb-initramfs (1.5.0) stable; urgency=medium
 
   * add extended rootfs support
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 21 Jul 2025 15:00:00 +0400
 
-wb-initenv (1.4.1) stable; urgency=medium
+wb-initramfs (1.4.1) stable; urgency=medium
 
   * Fix libupdate.sh
 

--- a/files/fstab
+++ b/files/fstab
@@ -1,6 +1,6 @@
-proc		/proc				proc		rw,nosuid,nodev,noexec,relatime		0 0
-sysfs		/sys				sysfs		rw,nosuid,nodev,noexec,relatime		0 0
-devtmpfs	/dev				devtmpfs	rw,nosuid,mode=755					0 0
-none		/sys/kernel/config	configfs	defaults							0 0
+proc        /proc               proc        rw,nosuid,nodev,noexec,relatime     0 0
+sysfs       /sys                sysfs       rw,nosuid,nodev,noexec,relatime     0 0
+devtmpfs    /dev                devtmpfs    rw,nosuid,mode=755                  0 0
+none        /sys/kernel/config  configfs    defaults                            0 0
 none        /dev/pts            devpts      gid=0,mode=620                      0 0
 tmpfs       /tmp                tmpfs       defaults                            0 0

--- a/files/init
+++ b/files/init
@@ -96,7 +96,7 @@ set_led_update_in_progress() {
 	led green trigger timer
 	led green delay_on 250
 	led green delay_off 250
-} 
+}
 
 set_led_prompt_user() {
 	led red trigger timer
@@ -106,8 +106,7 @@ set_led_prompt_user() {
 	led green trigger timer
 	led green delay_on 200
 	led green delay_off 200
-} 
-
+}
 
 check_fit_end_signature() {
 	local UPDATE_FIT_END_SIGNATURE="__WB_UPDATE_FIT_END__"
@@ -172,7 +171,7 @@ buzzer_update_beep() {
 	buzzer_on
 	sleep 0.1
 	buzzer_off
-	
+
 	sleep 0.3
 }
 
@@ -188,7 +187,7 @@ search_for_fit() {
 	for FNAME in ${FIT_NAMES}; do
 		local FIT="$DIR/$FNAME"
 		if [[ -e "${FIT}" ]]; then
-			if [[ ! -z "${FOUND_FIT_NAME}" ]]; then
+			if [[ -n "${FOUND_FIT_NAME}" ]]; then
 				>&2 echo "ERROR: multiple .fit found on ${SOURCE} (${DIR}): ${FOUND_FIT_NAME} and ${FNAME}. Leave just one from a list: ${FIT_NAMES}"
 				return 1
 			fi
@@ -197,7 +196,7 @@ search_for_fit() {
 		fi
 	done
 
-	if [[ ! -z "$FOUND_FIT_NAME" ]]; then
+	if [[ -n "$FOUND_FIT_NAME" ]]; then
 		if check_fit_end_signature "$DIR/$FOUND_FIT_NAME"; then
 			echo $FOUND_FIT_NAME
 			return 0
@@ -231,8 +230,6 @@ update_from_fit() {
 	buzzer_update_beep &&
 	wb-run-update --from-initramfs --no-mqtt --no-remove "${FIT_DIR}/${FIT_NAME}"
 }
-
-
 
 # @param $1 block device path spec
 # @param $2 .fit filename. If blank, look for all possible file names
@@ -276,7 +273,7 @@ wait_for_emmc() {
 update_from_emmc() {
 	local ROOT_PART="${EMMC}p2"
 	local DATA_PART="${EMMC}p6"
-	local FIT="/mnt/data/$1"
+	local FIT="/$1"
 	shift
 
 	wait_for_emmc
@@ -287,10 +284,11 @@ update_from_emmc() {
 	mkdir -p /mnt/data
 	if [[ -b "$DATA_PART" ]]; then
 		mount -t auto "${DATA_PART}" /mnt/data
+		FIT="/mnt/data$FIT"
 	else
 		mkdir -p /mnt/rootfs
 		mount -t auto "${ROOT_PART}" /mnt/rootfs
-		mount --bind /mnt/rootfs/mnt/data /mnt/data
+		FIT="/mnt/rootfs$FIT"
 	fi
 
 	[[ -f "$FIT" ]] &&
@@ -364,23 +362,23 @@ is_usb_gadget_supported() {
 }
 
 setup_usb_ram_mass_storage() {
-		# create usb_mass_storage first
-		MEMSIZE_KB=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
-		MEMSIZE_MB=$((MEMSIZE_KB / 1024))
-		mkdir -p "$RAMDISK_FS"
-		mount -t tmpfs -o size=${MEMSIZE_MB}M tmpfs ${RAMDISK_FS}
-		RAMDISK_SIZE_MB=$((MEMSIZE_MB-200))
-		dd if=/dev/zero of=${RAMDISK} bs=1M count=$RAMDISK_SIZE_MB  >/dev/null 2>&1
-		echo ",,b" | sfdisk ${RAMDISK}
-		losetup -o 1048576 /dev/loop0 ${RAMDISK}
-		mkfs.vfat /dev/loop0 -n "WB UPDATE"
-		mkdir -p "$USBDIR"
-		mount -t vfat /dev/loop0 "$USBDIR"
-		cp /usr/share/README.ramdisk.txt "${USBDIR}/README.txt"
-		umount "$USBDIR"
+	# create usb_mass_storage first
+	MEMSIZE_KB=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
+	MEMSIZE_MB=$((MEMSIZE_KB / 1024))
+	mkdir -p "$RAMDISK_FS"
+	mount -t tmpfs -o size=${MEMSIZE_MB}M tmpfs ${RAMDISK_FS}
+	RAMDISK_SIZE_MB=$((MEMSIZE_MB-200))
+	dd if=/dev/zero of=${RAMDISK} bs=1M count=$RAMDISK_SIZE_MB  >/dev/null 2>&1
+	echo ",,b" | sfdisk ${RAMDISK}
+	losetup -o 1048576 /dev/loop0 ${RAMDISK}
+	mkfs.vfat /dev/loop0 -n "WB UPDATE"
+	mkdir -p "$USBDIR"
+	mount -t vfat /dev/loop0 "$USBDIR"
+	cp /usr/share/README.ramdisk.txt "${USBDIR}/README.txt"
+	umount "$USBDIR"
 
-		echo "Activate Mass Storage device"
-		modprobe g_mass_storage file=${RAMDISK} iManufacturer="Wiren Board" iProduct="Wiren Board Update" iSerialNumber="$(cat /proc/device-tree/serial-number)"
+	echo "Activate Mass Storage device"
+	modprobe g_mass_storage file=${RAMDISK} iManufacturer="Wiren Board" iProduct="Wiren Board Update" iSerialNumber="$(cat /proc/device-tree/serial-number)"
 }
 
 setup_usb_ssh() {
@@ -501,7 +499,6 @@ case "$BOOTMODE" in
 		setup_usb_ssh &
 		;;
 esac
-
 
 sleep 1
 start_debug_console

--- a/files/wait_for_button.sh
+++ b/files/wait_for_button.sh
@@ -33,7 +33,7 @@ if [ "x${USE_ECHO}" == "xy" ]; then
             _ECHO_COUNTER=0
         fi
     }
-    
+
     echo_reset() {
         echo
     }
@@ -46,7 +46,6 @@ else
         true
     }
 fi
-
 
 if use_buzzer; then
     buzzer_init
@@ -65,7 +64,7 @@ if use_buzzer; then
             buzzer_off
         fi
     }
-else 
+else
     buzzer_wait() {
         true
     }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
В update_from_emmc аргументом приходит путь относительно корня раздела, и в случае расширеной рутфс возникает дублирование `/mnt/data/mnt/data/...`.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
в процессе
