### PR TITLE
libupdate.sh: fix platform detection

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initramfs (1.5.3) stable; urgency=medium
+
+  * libupdate.sh: fix platform detection
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 27 Aug 2025 18:00:00 +0400
+
 wb-initramfs (1.5.2) stable; urgency=medium
 
   * Fix factoryreset.fit path on extended rootfs

--- a/files/init
+++ b/files/init
@@ -75,7 +75,7 @@ for compat in $DT_COMPAT_LIST; do
 			sleep 1
 			break
 			;;
-		"wirenboard,wirenboard-700" )
+		"wirenboard,wirenboard-7xx" )
 			echo "Board is WB7"
 			BOARD_FAMILY="wb7"
 			break

--- a/files/libupdate.sh
+++ b/files/libupdate.sh
@@ -29,7 +29,7 @@ for compat in $DT_COMPAT_LIST; do
             LIB=wb6
             break
             ;;
-        "wirenboard,wirenboard-700" )
+        "wirenboard,wirenboard-7xx" )
             LIB=wb7
             break
             ;;


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
На wb7 грузимся в бутлет:
```sh
=> load mmc 1:2 0x42000000 /var/lib/wb-image-update/zImage
=> load mmc 1:2 0x43000000 /boot/dtbs/sun8i-r40-wirenboard733.dtb
=> bootz 0x42000000 - 0x43000000
```
Внутри бутлета:
```sh
~ # USE_BUZZER=y USE_ECHO=y WAIT_TIME=10 HOLD_TIME=4 wait_for_button
Unknown platform
```
Из-за этого нет ожидания подтверждения FR с пищанием баззера.

Почему так происходит - wirenboard-700 отсутствует в compatible:
```sh
tr < /proc/device-tree/compatible '\000' '\n'
wirenboard,wirenboard-733
wirenboard,wirenboard-73x
wirenboard,wirenboard-72x
wirenboard,wirenboard-720
wirenboard,wirenboard-7xx
allwinner,sun8i-r40
```

`wirenboard-7xx` прописан для:
```
arch/arm/boot/dts/sun8i-r40-wirenboard72x-initram.dts:7:
arch/arm/boot/dts/sun8i-r40-wirenboard720.dts:7:
arch/arm/boot/dts/sun8i-r40-wirenboard72x-factory.dts:8:
arch/arm/boot/dts/sun8i-r40-wirenboard742-38071cb.dts:7:
arch/arm/boot/dts/sun8i-r40-wirenboard731.dts:8:
arch/arm/boot/dts/sun8i-r40-wirenboard732.dts:12:
arch/arm/boot/dts/sun8i-r40-wirenboard730.dts:12:
arch/arm/boot/dts/sun8i-r40-wirenboard742.dts:6:
arch/arm/boot/dts/sun8i-r40-wirenboard741.dts:6:
arch/arm/boot/dts/sun8i-r40-wirenboard733.dts:7:
arch/arm/boot/dts/sun8i-r40-wirenboard734-38071cb.dts:7:
```

А `wirenboard-700` только для:
```
arch/arm/boot/dts/sun8i-r40-wirenboard72x-initram.dts:7:
arch/arm/boot/dts/sun8i-r40-wirenboard720.dts:7:
arch/arm/boot/dts/sun8i-r40-wirenboard72x-factory.dts:8:
arch/arm/boot/dts/sun8i-r40-wirenboard742.dts:6:
arch/arm/boot/dts/sun8i-r40-wirenboard741.dts:6:
```
___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
```sh
~ # sed -i 's/-700/-7xx/' /lib/libupdate.sh
~ # USE_BUZZER=y USE_ECHO=y WAIT_TIME=10 HOLD_TIME=4 wait_for_button
oooooooooo
```
Баззер работает при этом.


