### PR TITLE
Add bootmode=debug_console support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initramfs (1.5.4) stable; urgency=medium
+
+  * Add bootmode=debug_console support
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 28 Aug 2025 18:00:00 +0400
+
 wb-initramfs (1.5.3) stable; urgency=medium
 
   * libupdate.sh: fix platform detection

--- a/files/init
+++ b/files/init
@@ -455,6 +455,8 @@ is_board_wb85() {
 }
 
 case "$BOOTMODE" in
+	debug_console)
+		;;
 	update_auto)
 		is_usb_gadget_supported && setup_usb_ram_mass_storage
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При загрузке в бутлет вручную по дефолту попадаем в https://github.com/wirenboard/wb-initramfs/blob/85b7f5834a289ba06f9d2b2d740f29ea9a740f5d/files/init#L490-L512
Но оно крутится в while цикле и не проваливается в дебаг консоль. Для отладки хочется иметь возможность сразу попасть в дебаг консоль.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
На wb73:
```sh
=> setenv bootargs console=${console} bootmode=debug_console
=> load mmc 1:2 0x42000000 /var/lib/wb-image-update/zImage
=> load mmc 1:2 0x43000000 /boot/dtbs/sun8i-r40-wirenboard733.dtb
=> bootz 0x42000000 - 0x43000000
...
<linux boot>
...
console=ttyS0,115200 bootmode=debug_console
Boot mode: debug_console
Board is WB7


BusyBox v1.30.1 (Debian 1:1.30.1-6+deb11u1) built-in shell (ash)
Enter 'help' for a list of built-in commands.

sh: can't access tty; job control turned off
~ #
```

