### PR TITLE
Fix buzzer_init on wb8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-initramfs (1.5.5) stable; urgency=medium
 
   * Fix buzzer_init on wb8
 
- -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 28 Aug 2025 18:00:00 +0400
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 10 Apr 2026 17:00:00 +0400
 
 wb-initramfs (1.5.4) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-initramfs (1.5.5) stable; urgency=medium
+
+  * Fix buzzer_init on wb8
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 28 Aug 2025 18:00:00 +0400
+
 wb-initramfs (1.5.4) stable; urgency=medium
 
   * Add bootmode=debug_console support

--- a/files/libupdate.wb8.sh
+++ b/files/libupdate.wb8.sh
@@ -27,7 +27,7 @@ get_pwmchip_pwmbuzzer() {
             ;;
     esac
 
-    pwm_chip=$(grep -aH $compatible /sys/class/pwm/pwmchip*/device/of_node/compatible | grep -aEo "pwmchip[[:digit:]]+")
+    pwm_chip=$(grep -aH -- "$compatible" /sys/class/pwm/pwmchip*/device/of_node/compatible | grep -aEo "pwmchip[[:digit:]]+")
     echo "$pwm_chip $pwm_buzzer"
 }
 

--- a/files/libupdate.wb8.sh
+++ b/files/libupdate.wb8.sh
@@ -27,7 +27,7 @@ get_pwmchip_pwmbuzzer() {
             ;;
     esac
 
-    pwm_chip=$(grep -H $compatible /sys/class/pwm/pwmchip*/device/of_node/compatible | grep -Eo "pwmchip[[:digit:]]+")
+    pwm_chip=$(grep -aH $compatible /sys/class/pwm/pwmchip*/device/of_node/compatible | grep -aEo "pwmchip[[:digit:]]+")
     echo "$pwm_chip $pwm_buzzer"
 }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Проявилось только на трикси:

<img width="1159" height="816" alt="Screen Shot 2026-04-10 at 17 07 33" src="https://github.com/user-attachments/assets/5bf293a2-a5ab-480e-8b5b-f0d4ed563b2a" />

Почему так происходит:
```
$ grep -H allwinner,sun50i-t507-pwm /sys/class/pwm/pwmchip*/device/of_node/compatible | grep -Eo "pwmchip[[:digit:]]+"
grep: /sys/class/pwm/pwmchip0/device/of_node/compatible: binary file matches
```

то есть pwm_chip оказывается пустой: https://github.com/wirenboard/wb-initramfs/blob/f96388b1bd3682315fee5ab4f070505b34f7af45/files/libupdate.wb8.sh#L30

chip_buzzer оказывается равен " 1", pwmchip 1, pwmbuzzer пустой и все это зависает в цикле: https://github.com/wirenboard/wb-initramfs/blob/f96388b1bd3682315fee5ab4f070505b34f7af45/files/libupdate.wb8.sh#L38-L48

С фиксом получаем:
```sh
$ grep -aH allwinner,sun50i-t507-pwm /sys/class/pwm/pwmchip*/device/of_node/compatible | grep -aEo "pwmchip[[:digit:]]+"
pwmchip0
```
___________________________________
**Что поменялось для пользователей:**
нет зависания на инициализации баззера

___________________________________
**Как проверял/а:**
локально

